### PR TITLE
Fix-m4a-metadata-bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Before starting, you'll need to have the following installed:
 
 - [Go](https://golang.org/doc/install) (version 1.21 or higher)
 - [Docker](https://docs.docker.com/get-docker/) (to run the project in a container)
-- [FFmpeg](https://ffmpeg.org/download.html) (for audio processing)
+- [FFmpeg](https://ffmpeg.org/download.html) (for audio processing).
 
 ## Installation
 

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,11 @@ module github.com/EvolutionAPI/evolution-audio-converter
 
 go 1.21.1
 
-require github.com/gin-gonic/gin v1.10.0
+require (
+	github.com/gin-contrib/cors v1.7.2
+	github.com/gin-gonic/gin v1.10.0
+	github.com/joho/godotenv v1.5.1
+)
 
 require (
 	github.com/bytedance/sonic v1.11.6 // indirect
@@ -10,15 +14,14 @@ require (
 	github.com/cloudwego/base64x v0.1.4 // indirect
 	github.com/cloudwego/iasm v0.2.0 // indirect
 	github.com/gabriel-vasile/mimetype v1.4.3 // indirect
-	github.com/gin-contrib/cors v1.7.2 // indirect
 	github.com/gin-contrib/sse v0.1.0 // indirect
 	github.com/go-playground/locales v0.14.1 // indirect
 	github.com/go-playground/universal-translator v0.18.1 // indirect
 	github.com/go-playground/validator/v10 v10.20.0 // indirect
 	github.com/goccy/go-json v0.10.2 // indirect
-	github.com/joho/godotenv v1.5.1 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/klauspost/cpuid/v2 v2.2.7 // indirect
+	github.com/kr/text v0.2.0 // indirect
 	github.com/leodido/go-urn v1.4.0 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect

--- a/go.sum
+++ b/go.sum
@@ -6,6 +6,7 @@ github.com/cloudwego/base64x v0.1.4 h1:jwCgWpFanWmN8xoIUHa2rtzmkd5J2plF/dnLS6Xd/
 github.com/cloudwego/base64x v0.1.4/go.mod h1:0zlkT4Wn5C6NdauXdJRhSKRlJvmclQ1hhJgA0rcu/8w=
 github.com/cloudwego/iasm v0.2.0 h1:1KNIy1I1H9hNNFEEH3DVnI4UujN+1zjpuk6gwHLTssg=
 github.com/cloudwego/iasm v0.2.0/go.mod h1:8rXZaNYT2n95jn+zTI1sDr+IgcD2GVs0nlbbQPiEFhY=
+github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -38,6 +39,10 @@ github.com/klauspost/cpuid/v2 v2.0.9/go.mod h1:FInQzS24/EEf25PyTYn52gqo7WaD8xa02
 github.com/klauspost/cpuid/v2 v2.2.7 h1:ZWSB3igEs+d0qvnxR/ZBzXVmxkgt8DdzP6m9pfuVLDM=
 github.com/klauspost/cpuid/v2 v2.2.7/go.mod h1:Lcz8mBdAVJIBVzewtcLocK12l3Y+JytZYpaMropDUws=
 github.com/knz/go-libedit v1.10.1/go.mod h1:MZTVkCWyz0oBc7JOWP3wNAzd002ZbM/5hgShxwh4x8M=
+github.com/kr/pretty v0.3.0 h1:WgNl7dwNpEZ6jJ9k1snq4pZsg7DOEN8hP9Xw0Tsjwk0=
+github.com/kr/pretty v0.3.0/go.mod h1:640gp4NfQd8pI5XOwp5fnNeVWj67G7CFk/SaSQn7NBk=
+github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
+github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
 github.com/leodido/go-urn v1.4.0 h1:WT9HwE9SGECu3lg4d/dIA+jxlljEa1/ffXKmRjqdmIQ=
 github.com/leodido/go-urn v1.4.0/go.mod h1:bvxc+MVxLKB4z00jd1z+Dvzr47oO32F/QSNjSBOlFxI=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
@@ -51,6 +56,8 @@ github.com/pelletier/go-toml/v2 v2.2.2 h1:aYUidT7k73Pcl9nb2gScu7NSrKCSHIDE89b3+6
 github.com/pelletier/go-toml/v2 v2.2.2/go.mod h1:1t835xjRzz80PqgE6HHgN2JOsmgYu/h4qDAS4n929Rs=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/rogpeppe/go-internal v1.8.0 h1:FCbCCtXNOY3UtUuHUYaghJg4y7Fd14rXifAYUAtL9R8=
+github.com/rogpeppe/go-internal v1.8.0/go.mod h1:WmiCO8CzOY8rg0OYDC4/i/2WRWAB6poM+XZ2dLUbcbE=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
 github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
@@ -84,8 +91,9 @@ golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IV
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 google.golang.org/protobuf v1.34.1 h1:9ddQBjfCyZPOHPUiPxpYESBLc+T8P3E+Vo4IbKZgFWg=
 google.golang.org/protobuf v1.34.1/go.mod h1:c6P6GXX6sHbq/GpV6MGZEdwhWPcYBgnhAHhKbcUYpos=
-gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
+gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/main.go
+++ b/main.go
@@ -33,45 +33,47 @@ var (
 )
 
 func init() {
-	devMode := flag.Bool("dev", false, "Rodar em modo de desenvolvimento")
+	devMode := flag.Bool("dev", false, "Run in development mode")
 	flag.Parse()
 
 	if *devMode {
 		err := godotenv.Load()
 		if err != nil {
-			fmt.Println("Erro ao carregar o arquivo .env")
+			fmt.Println("Error loading .env file")
 		} else {
-			fmt.Println("Arquivo .env carregado com sucesso")
+			fmt.Println(".env file loaded successfully")
 		}
 	}
 
 	apiKey = os.Getenv("API_KEY")
 	if apiKey == "" {
-		fmt.Println("API_KEY não configurada no arquivo .env")
+		fmt.Println("API_KEY not configured in .env file")
 	}
 
 	allowOriginsEnv := os.Getenv("CORS_ALLOW_ORIGINS")
 	if allowOriginsEnv != "" {
 		allowedOrigins = strings.Split(allowOriginsEnv, ",")
+		fmt.Printf("Allowed origins: %v\n", allowedOrigins)
 	} else {
 		allowedOrigins = []string{"*"}
+		fmt.Printf("No allowed origins configured, allowing all")
 	}
 }
 
 func validateAPIKey(c *gin.Context) bool {
 	if apiKey == "" {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "Erro interno no servidor"})
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Internal server error (no API_KEY configured)"})
 		return false
 	}
 
 	requestApiKey := c.GetHeader("apikey")
 	if requestApiKey == "" {
-		c.JSON(http.StatusUnauthorized, gin.H{"error": "API_KEY não fornecida"})
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "API_KEY not provided"})
 		return false
 	}
 
 	if requestApiKey != apiKey {
-		c.JSON(http.StatusUnauthorized, gin.H{"error": "API_KEY inválida"})
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "Invalid API_KEY"})
 		return false
 	}
 
@@ -79,7 +81,10 @@ func validateAPIKey(c *gin.Context) bool {
 }
 
 func convertAudio(inputData []byte, inputFormat string, outputFormat string) ([]byte, int, error) {
+	fmt.Printf("Converting audio from %s to %s\n", inputFormat, outputFormat)
+	fmt.Printf("Input data size: %d bytes\n", len(inputData))
 	var cmd *exec.Cmd
+
 	switch outputFormat {
 	case "mp3":
 		cmd = exec.Command("ffmpeg", "-i", "pipe:0", "-f", "mp3", "pipe:1")
@@ -94,6 +99,7 @@ func convertAudio(inputData []byte, inputFormat string, outputFormat string) ([]
 	default:
 		cmd = exec.Command("ffmpeg", "-i", "pipe:0", "-c:a", "libopus", "-b:a", "16k", "-vbr", "on", "-compression_level", "10", "-ac", "1", "-ar", "16000", "-f", "ogg", "pipe:1")
 	}
+
 	outBuffer := bufferPool.Get().(*bytes.Buffer)
 	errBuffer := bufferPool.Get().(*bytes.Buffer)
 	defer bufferPool.Put(outBuffer)
@@ -114,18 +120,17 @@ func convertAudio(inputData []byte, inputFormat string, outputFormat string) ([]
 	convertedData := make([]byte, outBuffer.Len())
 	copy(convertedData, outBuffer.Bytes())
 
-	// Parsing da duração
 	outputText := errBuffer.String()
 	splitTime := strings.Split(outputText, "time=")
 
 	if len(splitTime) < 2 {
-		return nil, 0, errors.New("duração não encontrada")
+		return nil, 0, errors.New("duration not found")
 	}
 
 	re := regexp.MustCompile(`(\d+):(\d+):(\d+\.\d+)`)
 	matches := re.FindStringSubmatch(splitTime[2])
 	if len(matches) != 4 {
-		return nil, 0, errors.New("formato de duração não encontrado")
+		return nil, 0, errors.New("duration format not found")
 	}
 
 	hours, _ := strconv.ParseFloat(matches[1], 64)
@@ -330,8 +335,8 @@ func processAudio(c *gin.Context) {
 		return
 	}
 
-	outputFormat := c.DefaultPostForm("output_format", "ogg")
 	inputFormat := c.DefaultPostForm("input_format", "ogg")
+	outputFormat := c.DefaultPostForm("output_format", "ogg")
 
 	convertedData, duration, err := convertAudio(inputData, inputFormat, outputFormat)
 	if err != nil {
@@ -448,30 +453,56 @@ func processGifToMp4(c *gin.Context) {
 }
 
 func validateOrigin(origin string) bool {
-	if len(allowedOrigins) == 0 || (len(allowedOrigins) == 1 && allowedOrigins[0] == "*") {
+	fmt.Printf("Validating origin: %s\n", origin)
+	fmt.Printf("Allowed origins: %v\n", allowedOrigins)
+
+	if len(allowedOrigins) == 0 {
+		return true
+	}
+
+	if origin == "" {
 		return true
 	}
 
 	for _, allowed := range allowedOrigins {
+		allowed = strings.TrimSpace(allowed)
+
+		if allowed == "*" {
+			return true
+		}
+
 		if allowed == origin {
+			fmt.Printf("Origin %s matches %s\n", origin, allowed)
 			return true
 		}
 	}
+
+	fmt.Printf("Origin %s not found in allowed origins\n", origin)
 	return false
 }
 
 func originMiddleware() gin.HandlerFunc {
 	return func(c *gin.Context) {
 		origin := c.Request.Header.Get("Origin")
+		fmt.Printf("\n=== CORS Debug ===\n")
+		fmt.Printf("Received origin: %s\n", origin)
+		fmt.Printf("Complete headers: %+v\n", c.Request.Header)
+		fmt.Printf("Allowed origins: %v\n", allowedOrigins)
+		fmt.Printf("=================\n")
+
 		if origin == "" {
 			origin = c.Request.Header.Get("Referer")
+			fmt.Printf("Empty origin, using Referer: %s\n", origin)
 		}
 
 		if !validateOrigin(origin) {
-			c.JSON(http.StatusForbidden, gin.H{"error": "Origem não permitida"})
+			fmt.Printf("❌ Origin rejected: %s\n", origin)
+			c.JSON(http.StatusForbidden, gin.H{"error": "Origin not allowed"})
 			c.Abort()
 			return
 		}
+
+		fmt.Printf("✅ Origin accepted: %s\n", origin)
 		c.Next()
 	}
 }
@@ -521,10 +552,10 @@ func probeVideoFormat(inputData []byte) (string, error) {
 		if i+1 >= len(lines) {
 			break
 		}
-		
+
 		codecType := strings.TrimSpace(lines[i])
 		codecName := strings.TrimSpace(lines[i+1])
-		
+
 		if codecType == "video" {
 			videoCodec = codecName
 		} else if codecType == "audio" {
@@ -1037,6 +1068,7 @@ func main() {
 	config.AllowOrigins = allowedOrigins
 	config.AllowMethods = []string{"POST", "GET", "OPTIONS"}
 	config.AllowHeaders = []string{"Origin", "Content-Type", "Accept", "Authorization", "apikey"}
+	config.AllowCredentials = true
 
 	router.Use(cors.New(config))
 	router.Use(originMiddleware())

--- a/main.go
+++ b/main.go
@@ -83,9 +83,9 @@ func convertAudio(inputData []byte, inputFormat string, outputFormat string) ([]
 	case "mp3":
 		cmd = exec.Command("ffmpeg", "-i", "pipe:0", "-f", "mp3", "pipe:1")
 	case "wav":
-			cmd = exec.Command("ffmpeg", "-i", "pipe:0", "-f", "wav", "pipe:1")
+		cmd = exec.Command("ffmpeg", "-i", "pipe:0", "-f", "wav", "pipe:1")
 	default:
-        if inputFormat == "webm" {
+		if inputFormat == "webm" {
             // Custom settings for webm to ogg conversion
 			fmt.Println("Conversão de webm para ogg")
             cmd = exec.Command("ffmpeg", "-i", "pipe:0", "-acodec", "libopus", "-b:a", "16k", "-vbr", "on", "-compression_level", "10", "-ac", "1", "-ar", "16000", "-f", "ogg", "pipe:1")

--- a/main.go
+++ b/main.go
@@ -85,14 +85,7 @@ func convertAudio(inputData []byte, inputFormat string, outputFormat string) ([]
 	case "wav":
 		cmd = exec.Command("ffmpeg", "-i", "pipe:0", "-f", "wav", "pipe:1")
 	default:
-		if inputFormat == "webm" {
-            // Custom settings for webm to ogg conversion
-			fmt.Println("Conversão de webm para ogg")
-            cmd = exec.Command("ffmpeg", "-i", "pipe:0", "-acodec", "libopus", "-b:a", "16k", "-vbr", "on", "-compression_level", "10", "-ac", "1", "-ar", "16000", "-f", "ogg", "pipe:1")
-        } else {
-            // Default settings for other formats to ogg
-			cmd = exec.Command("ffmpeg", "-i", "pipe:0", "-acodec", "libopus", "-ac", "1", "-ar", "16000", "-f", "ogg", "pipe:1")
-		}
+		cmd = exec.Command("ffmpeg", "-i", "pipe:0", "-c:a", "libopus", "-b:a", "16k", "-vbr", "on", "-compression_level", "10", "-ac", "1", "-ar", "16000", "-f", "ogg", "pipe:1")
 	}
 	outBuffer := bufferPool.Get().(*bytes.Buffer)
 	errBuffer := bufferPool.Get().(*bytes.Buffer)

--- a/main.go
+++ b/main.go
@@ -84,6 +84,12 @@ func convertAudio(inputData []byte, inputFormat string, outputFormat string) ([]
 		cmd = exec.Command("ffmpeg", "-i", "pipe:0", "-f", "mp3", "pipe:1")
 	case "wav":
 		cmd = exec.Command("ffmpeg", "-i", "pipe:0", "-f", "wav", "pipe:1")
+	case "aac":
+		cmd = exec.Command("ffmpeg", "-i", "pipe:0", "-c:a", "aac", "-b:a", "128k", "-f", "adts", "pipe:1")
+	case "amr":
+		cmd = exec.Command("ffmpeg", "-i", "pipe:0", "-c:a", "libopencore_amrnb", "-b:a", "12.2k", "-f", "amr", "pipe:1")
+	case "m4a":
+		cmd = exec.Command("ffmpeg", "-i", "pipe:0", "-c:a", "aac", "-b:a", "128k", "-f", "ipod", "pipe:1")
 	default:
 		cmd = exec.Command("ffmpeg", "-i", "pipe:0", "-c:a", "libopus", "-b:a", "16k", "-vbr", "on", "-compression_level", "10", "-ac", "1", "-ar", "16000", "-f", "ogg", "pipe:1")
 	}

--- a/main.go
+++ b/main.go
@@ -82,6 +82,8 @@ func convertAudio(inputData []byte, format string) ([]byte, int, error) {
 	switch format {
 	case "mp3":
 		cmd = exec.Command("ffmpeg", "-i", "pipe:0", "-f", "mp3", "pipe:1")
+	case "wav":
+		cmd = exec.Command("ffmpeg", "-i", "pipe:0", "-f", "wav", "pipe:1")
 	default:
 		cmd = exec.Command("ffmpeg", "-i", "pipe:0", "-ac", "1", "-ar", "16000", "-c:a", "libopus", "-f", "ogg", "pipe:1")
 	}

--- a/main.go
+++ b/main.go
@@ -686,6 +686,288 @@ func processVideoToMp4(c *gin.Context) {
 	processConversion(inputData, inputFormat, "otros métodos")
 }
 
+func convertImage(inputData []byte, inputFormat string, outputFormat string) ([]byte, error) {
+	fmt.Printf("Iniciando conversión de imagen %s a %s (%d bytes)\n", inputFormat, outputFormat, len(inputData))
+
+	// Siempre usar archivos temporales para la conversión de imágenes
+	return convertImageUsingTempFiles(inputData, inputFormat, outputFormat)
+}
+
+// Función para convertir imagen usando archivos temporales
+func convertImageUsingTempFiles(inputData []byte, inputFormat string, outputFormat string) ([]byte, error) {
+	fmt.Println("Usando archivos temporales para la conversión de imagen")
+
+	// Crear archivo temporal para entrada
+	inputFile, err := os.CreateTemp("", fmt.Sprintf("input-*.%s", inputFormat))
+	if err != nil {
+		return nil, fmt.Errorf("error al crear archivo temporal de entrada: %v", err)
+	}
+	inputPath := inputFile.Name()
+	defer func() {
+		inputFile.Close()
+		os.Remove(inputPath) // Limpiar al finalizar
+		fmt.Printf("Archivo temporal de entrada eliminado: %s\n", inputPath)
+	}()
+
+	// Escribir datos de entrada al archivo temporal
+	bytesWritten, err := inputFile.Write(inputData)
+	if err != nil {
+		return nil, fmt.Errorf("error al escribir en archivo temporal: %v", err)
+	}
+	fmt.Printf("Datos escritos en archivo temporal: %d bytes en %s\n", bytesWritten, inputPath)
+	inputFile.Close() // Cerrar archivo después de escribir
+
+	// Crear archivo temporal para salida
+	outputFile, err := os.CreateTemp("", fmt.Sprintf("output-*.%s", outputFormat))
+	if err != nil {
+		return nil, fmt.Errorf("error al crear archivo temporal de salida: %v", err)
+	}
+	outputPath := outputFile.Name()
+	outputFile.Close() // Cerrar para que ffmpeg pueda escribir en él
+	defer func() {
+		os.Remove(outputPath) // Limpiar al finalizar
+		fmt.Printf("Archivo temporal de salida eliminado: %s\n", outputPath)
+	}()
+
+	// Verificar que el archivo de entrada existe y tiene tamaño
+	inputInfo, err := os.Stat(inputPath)
+	if err != nil {
+		return nil, fmt.Errorf("error al verificar archivo de entrada: %v", err)
+	}
+	fmt.Printf("Archivo de entrada verificado: %s (tamaño: %d bytes)\n", inputPath, inputInfo.Size())
+
+	// Configurar comando ffmpeg según el formato de salida
+	var cmd *exec.Cmd
+	
+	switch outputFormat {
+	case "png":
+		cmd = exec.Command("ffmpeg",
+			"-i", inputPath,          // Archivo de entrada
+			"-f", "image2",           // Formato de imagen
+			"-c:v", "png",            // Codec PNG
+			"-y",                     // Sobrescribir sin preguntar
+			outputPath)               // Archivo de salida
+	case "jpg", "jpeg":
+		cmd = exec.Command("ffmpeg",
+			"-i", inputPath,          // Archivo de entrada
+			"-f", "image2",           // Formato de imagen
+			"-c:v", "mjpeg",          // Codec JPEG
+			"-q:v", "2",              // Calidad (2 es alta calidad, rango 2-31)
+			"-y",                     // Sobrescribir sin preguntar
+			outputPath)               // Archivo de salida
+	default:
+		return nil, fmt.Errorf("formato de salida no soportado: %s", outputFormat)
+	}
+
+	// Capturar salida de error
+	var errBuffer bytes.Buffer
+	cmd.Stderr = &errBuffer
+
+	fmt.Println("Ejecutando FFmpeg para conversión de imagen...")
+	fmt.Printf("Comando: %v\n", cmd.Args)
+
+	err = cmd.Run()
+	if err != nil {
+		fmt.Printf("Error durante la conversión de imagen: %v\n", err)
+		fmt.Printf("Detalles del error: %s\n", errBuffer.String())
+		return nil, fmt.Errorf("error en conversión de imagen: %v, detalles: %s", err, errBuffer.String())
+	}
+
+	// Verificar que el archivo de salida existe y tiene tamaño
+	outputInfo, err := os.Stat(outputPath)
+	if err != nil {
+		return nil, fmt.Errorf("error al verificar archivo de salida: %v", err)
+	}
+	fmt.Printf("Archivo de salida verificado: %s (tamaño: %d bytes)\n", outputPath, outputInfo.Size())
+
+	// Leer archivo de salida
+	outputData, err := os.ReadFile(outputPath)
+	if err != nil {
+		return nil, fmt.Errorf("error al leer archivo de salida: %v", err)
+	}
+
+	if len(outputData) == 0 {
+		return nil, errors.New("la conversión produjo un archivo de salida vacío")
+	}
+
+	fmt.Printf("Conversión de imagen exitosa. Tamaño: %d bytes\n", len(outputData))
+	return outputData, nil
+}
+
+func fetchImageFromURL(url string) ([]byte, error) {
+	if url == "" {
+		return nil, errors.New("URL vacía proporcionada")
+	}
+
+	fmt.Printf("Intentando descargar imagen desde: %s\n", url)
+
+	// Configurar un cliente HTTP con timeout
+	client := &http.Client{
+		Timeout: 30 * time.Second,
+	}
+
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("error al crear solicitud: %v", err)
+	}
+
+	// Agregar User-Agent para evitar restricciones
+	req.Header.Set("User-Agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("error al acceder URL: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("estado de respuesta inválido: %d", resp.StatusCode)
+	}
+
+	fmt.Printf("Descarga iniciada. Content-Length: %s\n", resp.Header.Get("Content-Length"))
+
+	// Leer con un buffer para evitar problemas de memoria
+	var buffer bytes.Buffer
+	_, err = io.Copy(&buffer, resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("error al leer datos: %v", err)
+	}
+
+	data := buffer.Bytes()
+	fmt.Printf("Descarga completada. Tamaño: %d bytes\n", len(data))
+
+	return data, nil
+}
+
+func processImageConversion(c *gin.Context) {
+	// Función para manejar errores y responder al cliente
+	handleError := func(statusCode int, err error, source string) {
+		errorMsg := err.Error()
+		fmt.Printf("Error en %s: %v\n", source, err)
+		c.JSON(statusCode, gin.H{"error": errorMsg})
+	}
+
+	// Función para procesar la conversión y responder al cliente
+	processConversion := func(inputData []byte, inputFormat string, outputFormat string, source string) {
+		fmt.Printf("Procesando imagen %s a %s desde %s (%d bytes)\n", inputFormat, outputFormat, source, len(inputData))
+
+		// Implementar recuperación de pánico
+		defer func() {
+			if r := recover(); r != nil {
+				fmt.Printf("Recuperado de pánico en conversión: %v\n", r)
+				c.JSON(http.StatusInternalServerError, gin.H{
+					"error": fmt.Sprintf("Error interno durante la conversión: %v", r),
+				})
+			}
+		}()
+
+		convertedData, err := convertImage(inputData, inputFormat, outputFormat)
+		if err != nil {
+			handleError(http.StatusInternalServerError, err, "conversión")
+			return
+		}
+
+		// Verificar que los datos convertidos no estén vacíos
+		if len(convertedData) == 0 {
+			handleError(http.StatusInternalServerError,
+				errors.New("la conversión produjo un archivo vacío"), "validación de salida")
+			return
+		}
+
+		fmt.Printf("Conversión exitosa. Enviando respuesta (%d bytes)\n", len(convertedData))
+		c.JSON(http.StatusOK, gin.H{
+			"image":  base64.StdEncoding.EncodeToString(convertedData),
+			"format": outputFormat,
+		})
+	}
+
+	// Validar API Key
+	if !validateAPIKey(c) {
+		return
+	}
+
+	// Log para depuración
+	fmt.Printf("Recibida solicitud de conversión de imagen. Content-Type: %s\n", c.ContentType())
+
+	// Obtener formatos de entrada y salida
+	inputFormat := c.DefaultPostForm("input_format", "webp")
+	outputFormat := c.DefaultPostForm("output_format", "png")
+
+	// Validar formato de salida
+	if outputFormat != "png" && outputFormat != "jpg" && outputFormat != "jpeg" {
+		handleError(http.StatusBadRequest, 
+			errors.New("formato de salida no válido, use 'png', 'jpg' o 'jpeg'"), "validación")
+		return
+	}
+
+	// Verificar si hay una URL en el formulario
+	formUrl := c.PostForm("url")
+	if formUrl != "" {
+		fmt.Printf("URL encontrada en form-data: %s\n", formUrl)
+		inputData, err := fetchImageFromURL(formUrl)
+		if err != nil {
+			handleError(http.StatusBadRequest, err, "obtención de imagen (form)")
+			return
+		}
+		processConversion(inputData, inputFormat, outputFormat, "form-data")
+		return
+	}
+
+	// Verificar si hay una URL en los parámetros de consulta
+	queryUrl := c.Query("url")
+	if queryUrl != "" {
+		fmt.Printf("URL encontrada en query params: %s\n", queryUrl)
+		inputData, err := fetchImageFromURL(queryUrl)
+		if err != nil {
+			handleError(http.StatusBadRequest, err, "obtención de imagen (query)")
+			return
+		}
+		processConversion(inputData, inputFormat, outputFormat, "query params")
+		return
+	}
+
+	// Verificar si hay datos en JSON
+	var jsonData struct {
+		URL         string `json:"url"`
+		InputFormat string `json:"input_format"`
+		OutputFormat string `json:"output_format"`
+	}
+	if err := c.ShouldBindJSON(&jsonData); err == nil && jsonData.URL != "" {
+		fmt.Printf("URL encontrada en JSON: %s\n", jsonData.URL)
+		inputData, err := fetchImageFromURL(jsonData.URL)
+		if err != nil {
+			handleError(http.StatusBadRequest, err, "obtención de imagen (json)")
+			return
+		}
+
+		// Usar los formatos del JSON si están disponibles
+		if jsonData.InputFormat != "" {
+			inputFormat = jsonData.InputFormat
+		}
+		if jsonData.OutputFormat != "" {
+			outputFormat = jsonData.OutputFormat
+			// Validar formato de salida
+			if outputFormat != "png" && outputFormat != "jpg" && outputFormat != "jpeg" {
+				handleError(http.StatusBadRequest, 
+					errors.New("formato de salida no válido, use 'png', 'jpg' o 'jpeg'"), "validación")
+				return
+			}
+		}
+
+		processConversion(inputData, inputFormat, outputFormat, "JSON")
+		return
+	}
+
+	// Si no hay URL, intentar otros métodos de entrada
+	fmt.Println("No se encontró URL, intentando otros métodos de entrada")
+	inputData, err := getInputData(c)
+	if err != nil {
+		handleError(http.StatusBadRequest, err, "obtención de datos de entrada")
+		return
+	}
+	processConversion(inputData, inputFormat, outputFormat, "otros métodos")
+}
+
 func main() {
 	port := os.Getenv("PORT")
 	if port == "" {
@@ -705,6 +987,7 @@ func main() {
 	router.POST("/process-audio", processAudio)
 	router.POST("/gif-to-mp4", processGifToMp4)
 	router.POST("/video-to-mp4", processVideoToMp4)
+	router.POST("/convert-image", processImageConversion)
 
 	router.Run(":" + port)
 }

--- a/main.go
+++ b/main.go
@@ -529,11 +529,6 @@ func validateOrigin(origin string) bool {
 func originMiddleware() gin.HandlerFunc {
 	return func(c *gin.Context) {
 		origin := c.Request.Header.Get("Origin")
-		fmt.Printf("\n=== CORS Debug ===\n")
-		fmt.Printf("Received origin: %s\n", origin)
-		fmt.Printf("Complete headers: %+v\n", c.Request.Header)
-		fmt.Printf("Allowed origins: %v\n", allowedOrigins)
-		fmt.Printf("=================\n")
 
 		if origin == "" {
 			origin = c.Request.Header.Get("Referer")
@@ -541,13 +536,13 @@ func originMiddleware() gin.HandlerFunc {
 		}
 
 		if !validateOrigin(origin) {
-			fmt.Printf("❌ Origin rejected: %s\n", origin)
+			fmt.Printf("Origin rejected: %s\n", origin)
 			c.JSON(http.StatusForbidden, gin.H{"error": "Origin not allowed"})
 			c.Abort()
 			return
 		}
 
-		fmt.Printf("✅ Origin accepted: %s\n", origin)
+		fmt.Printf("Origin accepted: %s\n", origin)
 		c.Next()
 	}
 }


### PR DESCRIPTION
add MP4/M4A detection, improve FFmpeg argument handling, and introduce temporary file usage for specific formats. Also, extract duration from FFmpeg output for better error handling and logging.

## Summary by Sourcery

Add richer media conversion capabilities and improve robustness of audio processing and CORS/origin handling.

New Features:
- Add detection and special handling of MP4/M4A audio inputs using temporary files to support formats that require seeking.
- Expose new HTTP endpoints to convert GIFs to MP4, generic videos to MP4, and arbitrary images to PNG, accepting input via file, URL, or JSON payload.

Enhancements:
- Refine FFmpeg argument handling across audio formats and extract conversion duration from stderr for more reliable duration reporting and error messages.
- Improve logging and error messages (now in English) for API key validation, CORS origin configuration, and media conversion flows.
- Tighten origin validation middleware, including support for configured allowed origins and credentials in CORS, while preserving a permissive default when no origins are configured.

Build:
- Update go.mod to promote gin-contrib/cors and godotenv to direct dependencies and add required transitive modules.

Documentation:
- Minor README copy tweaks related to FFmpeg description punctuation.